### PR TITLE
Scan deep directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,23 @@ expect('notlowercase.php')->toReturnLowercase();
 
 ### Scan directory
 
-You can scan all directory files at once
+```bash
+directory
+├── file.js
+├── file.php
+├── subdirectory
+    ├── file.json
+    ├── file1.php
+    ├── file2.php
+```
 
+- To scan all the php files in `directory` and all its subdirectories (`file.php`, `file1.php` and `file2.php`), we can use:
 ```php
 expect('directory')->toReturnLowercase();
 ```
+
+- We can also specify the scan depth using `depth`.
+```php
+expect('directory')->toReturnLowercase(depth:0);
+```
+In this case it will only scan direct php file which is `file.php`.

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -6,7 +6,7 @@ use Pest\Expectation as PestExpectation;
 
 expect()->extend(
     'toReturnLowercase',
-    function (?int $depth = null): PestExpectation {
+    function (int $depth = -1): PestExpectation {
         $files = [$this->value];
 
         if (is_dir($files[0])) {

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -6,17 +6,11 @@ use Pest\Expectation as PestExpectation;
 
 expect()->extend(
     'toReturnLowercase',
-    function (): PestExpectation {
+    function (?int $depth = null): PestExpectation {
         $files = [$this->value];
 
         if (is_dir($files[0])) {
-            $directory = $files[0];
-
-            if ($files = scandir($files[0])) {
-                $files = array_diff($files, ['.', '..']);
-                $files = array_filter($files, 'isPhp');
-                $files = array_map(fn (string $file): string => $directory.DIRECTORY_SEPARATOR.$file, $files);
-            }
+            $files = getFilesIn($files[0], $depth);
 
             if ($files === []) {
                 expect(true)->toBeTrue();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,8 +1,45 @@
 <?php
 
+function isDirOrPhp(string $maybeFile): bool
+{
+    return isDir($maybeFile) || isPhp($maybeFile);
+}
+
+function isDir(string $maybeDir): bool
+{
+    return !str_contains($maybeDir, '.');
+}
+
 function isPhp(string $file): bool
 {
     $exploded = explode('.', $file);
 
     return end($exploded) === 'php';
+}
+
+/**
+ * @return array<string>
+ */
+function getFilesIn(string $directory, ?int $depth = null): array
+{
+    $allFiles = [];
+
+    if ($files = scandir($directory)) {
+        $files = array_diff($files, ['.', '..']);
+        $files = array_filter($files, 'isDirOrPhp');
+
+        foreach($files as $file) {
+            if (isDir($file)) {
+                if (is_null($depth) || $depth > 0) {
+                    $allFiles = array_merge(getFilesIn($directory.DIRECTORY_SEPARATOR.$file, is_null($depth) ? $depth : $depth - 1), $allFiles);
+                }
+            } else {
+                $allFiles[] = $directory.DIRECTORY_SEPARATOR.$file;
+            }
+        }
+
+        return $allFiles;
+    }
+
+    return [];
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -20,7 +20,7 @@ function isPhp(string $file): bool
 /**
  * @return array<string>
  */
-function getFilesIn(string $directory, ?int $depth = null): array
+function getFilesIn(string $directory, int $depth = -1): array
 {
     $allFiles = [];
 
@@ -30,8 +30,9 @@ function getFilesIn(string $directory, ?int $depth = null): array
 
         foreach ($files as $file) {
             if (isDir($file)) {
-                if (is_null($depth) || $depth > 0) {
-                    $allFiles = array_merge(getFilesIn($directory.DIRECTORY_SEPARATOR.$file, is_null($depth) ? $depth : $depth - 1), $allFiles);
+                if ($depth !== 0) {
+                    $deeperFiles = getFilesIn($directory.DIRECTORY_SEPARATOR.$file, $depth < 0 ? $depth : $depth - 1);
+                    $allFiles = array_merge($deeperFiles, $allFiles);
                 }
             } else {
                 $allFiles[] = $directory.DIRECTORY_SEPARATOR.$file;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -7,7 +7,7 @@ function isDirOrPhp(string $maybeFile): bool
 
 function isDir(string $maybeDir): bool
 {
-    return !str_contains($maybeDir, '.');
+    return ! str_contains($maybeDir, '.');
 }
 
 function isPhp(string $file): bool
@@ -28,7 +28,7 @@ function getFilesIn(string $directory, ?int $depth = null): array
         $files = array_diff($files, ['.', '..']);
         $files = array_filter($files, 'isDirOrPhp');
 
-        foreach($files as $file) {
+        foreach ($files as $file) {
             if (isDir($file)) {
                 if (is_null($depth) || $depth > 0) {
                     $allFiles = array_merge(getFilesIn($directory.DIRECTORY_SEPARATOR.$file, is_null($depth) ? $depth : $depth - 1), $allFiles);

--- a/tests/Fixtures/shouldAllBeLowercase/subdirectory/notAllLowerCase.php
+++ b/tests/Fixtures/shouldAllBeLowercase/subdirectory/notAllLowerCase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    '',
+    'f@issa!oux',
+    'pest',
+    'plugin',
+    'inside',
+    'lowercase',
+    'loWer',
+    'case',
+];

--- a/tests/Unit/helpers/getFilesIn.php
+++ b/tests/Unit/helpers/getFilesIn.php
@@ -19,3 +19,9 @@ it('gets all php files in directory depth 1', function (): void {
 
     expect($files)->toBeArray()->toHaveCount(6);
 });
+
+it('gets all php files in directory and subdirectories on negative depth', function (): void {
+    $files = getFilesIn('tests/Fixtures', depth: -4);
+
+    expect($files)->toBeArray()->toHaveCount(7);
+});

--- a/tests/Unit/helpers/getFilesIn.php
+++ b/tests/Unit/helpers/getFilesIn.php
@@ -1,0 +1,21 @@
+<?php
+
+uses()->group('helpers');
+
+it('gets all php files in directory and subdirectories', function (): void {
+    $files = getFilesIn('tests/Fixtures');
+
+    expect($files)->toBeArray()->toHaveCount(7);
+});
+
+it('gets all direct php files in directory', function (): void {
+    $files = getFilesIn('tests/Fixtures', depth: 0);
+
+    expect($files)->toBeArray()->toHaveCount(2);
+});
+
+it('gets all php files in directory depth 1', function (): void {
+    $files = getFilesIn('tests/Fixtures', depth: 1);
+
+    expect($files)->toBeArray()->toHaveCount(6);
+});

--- a/tests/toReturnLowercase.php
+++ b/tests/toReturnLowercase.php
@@ -19,7 +19,7 @@ it('passes when directory is empty', function (): void {
 
 it('passes when all directory files content are lowercase', function (): void {
     expect('tests/Fixtures/shouldAllBeLowercase')
-        ->toReturnLowercase();
+        ->toReturnLowercase(depth: 0);
 });
 
 it('fails', function (): void {
@@ -44,5 +44,10 @@ it('fails when directory does not exist', function (): void {
 
 it('fails when not all directory files content are lowercase', function (): void {
     expect('tests/Fixtures/shouldAllBeLowercase1')
+        ->toReturnLowercase();
+})->throws(ExpectationFailedException::class);
+
+it('fails when not all subdirectories files content are lowercase', function (): void {
+    expect('tests/Fixtures/shouldAllBeLowercase')
         ->toReturnLowercase();
 })->throws(ExpectationFailedException::class);


### PR DESCRIPTION
```bash
directory
├── file.php
├── subdirectory
    ├── file1.php
    ├── file2.php
```

- To scan all the php files in `directory` (`file.php`, `file1.php` and `file2.php`), we can use:
```php
expect('directory')->toReturnLowercase();
```

- We can also specify the scan depth using `depth`.
```php
expect('directory')->toReturnLowercase(depth:0);
```
🔝 This will scan only direct php files (`file.php`).