### PR TITLE
`toReturnSingleWords()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Make sure a file or directory files returns an array with unique values.
 expect('file.php')->toReturnUnique();
 ```
 
+### toReturnSingleWords
+Make sure a file or directory files returns an array with single words.
+```php
+expect('file.php')->toReturnSingleWords();
+```
+
 ----
 
 ### Success

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -99,7 +99,35 @@ final class Expectation
 
             $duplicates = array_diff_assoc($content, array_unique($content));
 
-            expect($duplicates)->toBeEmpty('Duplicates found:'.implode(',', $duplicates)." in $file");
+            expect($duplicates)->toBeEmpty('Duplicates found: '.implode(',', $duplicates)." in $file");
+        }
+
+        return new PestExpectation($this->value);
+    }
+
+    /**
+     * @return PestExpectation<string>
+     */
+    public function toReturnSingleWords(int $depth = -1): PestExpectation
+    {
+        $this->fetchFilesIfDirectory($depth);
+
+        if ($this->files === []) {
+            expect(true)->toBeTrue();
+
+            return new PestExpectation($this->value);
+        }
+
+        foreach ($this->files as $file) {
+            $this->checkFileExistence($file);
+
+            $content = $this->getContentFrom($file);
+
+            $notSingle = array_filter($content, function (string $word): bool {
+                return str_contains(trim($word), ' ');
+            });
+
+            expect($notSingle)->toBeEmpty('Not single words detected: '.implode(',', $notSingle)." in $file");
         }
 
         return new PestExpectation($this->value);

--- a/tests/Fixtures/directory/subdirectory/notAllUnique.php
+++ b/tests/Fixtures/directory/subdirectory/notAllUnique.php
@@ -6,6 +6,7 @@ return [
     '',
     'f@issa!oux',
     'pest',
+    'plugin inside',
     'plugin',
     'inside',
     'duplicate',

--- a/tests/Fixtures/directory1/notAllUnique.php
+++ b/tests/Fixtures/directory1/notAllUnique.php
@@ -6,6 +6,7 @@ return [
     '',
     'f@issa!oux',
     'pest',
+    'plugin inside',
     'plugin',
     'inside',
     'duplicate',

--- a/tests/Fixtures/returnsDuplicates.php
+++ b/tests/Fixtures/returnsDuplicates.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 return [
     '',
     'f@issa!oux',
+    'pest plugin',
+    'pest plugin inside',
     'pest',
     'plugin',
     'inside',

--- a/tests/toReturnSingleWords.php
+++ b/tests/toReturnSingleWords.php
@@ -1,0 +1,66 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('passes', function (): void {
+    expect('tests/Fixtures/returnsMultipleDuplicates.php')
+        ->toReturnSingleWords();
+});
+
+it('passes with not', function (): void {
+    expect('tests/Fixtures/returnsUnique.php')
+        ->not->toReturnSingleWords();
+});
+
+it('passes when directory is empty', function (): void {
+    expect('tests/Fixtures/empty')
+        ->toReturnSingleWords();
+});
+
+it('passes when all directory files content are single words', function (): void {
+    expect('tests/Fixtures/directory')
+        ->toReturnSingleWords(depth: 0);
+});
+
+it('fails', function (): void {
+    expect('tests/Fixtures/returnsUnique.php')
+        ->toReturnSingleWords();
+})->throws(ExpectationFailedException::class);
+
+it('fails with not', function (): void {
+    expect('tests/Fixtures/returnsMultipleDuplicates.php')
+        ->not->toReturnSingleWords();
+})->throws(ExpectationFailedException::class);
+
+it('fails when file does not exist', function (): void {
+    expect('tests/Fixtures/notExist.php')
+        ->toReturnSingleWords();
+})->throws(ExpectationFailedException::class, 'tests/Fixtures/notExist.php not found');
+
+it('fails when directory does not exist', function (): void {
+    expect('tests/Fixtures/notExist')
+        ->toReturnSingleWords();
+})->throws(ExpectationFailedException::class);
+
+it('fails when not all directory files content are single words', function (): void {
+    expect('tests/Fixtures/directory1')
+        ->toReturnSingleWords();
+})->throws(ExpectationFailedException::class);
+
+it('fails when not all subdirectories files content are single words', function (): void {
+    expect('tests/Fixtures/directory')
+        ->toReturnSingleWords();
+})->throws(ExpectationFailedException::class);
+
+it('displays word detected', function (): void {
+    expect('tests/Fixtures/directory')->toReturnSingleWords();
+})->throws(ExpectationFailedException::class, 'Not single words detected: plugin inside');
+
+it('displays multiple not single words detected', function (): void {
+    expect('tests/Fixtures/returnsDuplicates.php')
+        ->toReturnSingleWords();
+})->throws(ExpectationFailedException::class, 'pest plugin,pest plugin inside');
+
+it('displays file where error detected', function (): void {
+    expect('tests/Fixtures/directory')->toReturnSingleWords();
+})->throws(ExpectationFailedException::class, 'notAllUnique.php');


### PR DESCRIPTION
`toReturnSingleWords()` makes sure your php files return an array with single words.

```php
expect('file.php')->toReturnSingleWords();
```

#### Success
`file.php` returns all single words.
```php
// file.php

return [
    'pestphp',
    'pest',
    'plugin',
];
```

#### Fails
`file.php` returns a value that contains more than one word (`plugin inside`).
```php
// file.php

return [
    'pestphp',
    'pest',
    'plugin',
    'plugin inside',
    'pest',
];
```