### PR TITLE
`toBeOrdered()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This plugin checks what's inside the files.
 
 [![Tests](https://github.com/faissaloux/pest-plugin-inside/actions/workflows/tests.yml/badge.svg)](https://github.com/faissaloux/pest-plugin-inside/actions/workflows/tests.yml) ![Codecov](https://img.shields.io/codecov/c/github/faissaloux/pest-plugin-inside) ![Packagist Version](https://img.shields.io/packagist/v/faissaloux/pest-plugin-inside) ![Packagist License](https://img.shields.io/packagist/l/faissaloux/pest-plugin-inside)
 
-## Available Methods
+## Available Expectations
 ### toReturnLowercase
 Make sure a file or directory files returns an array with all lowercase values.
 ```php
@@ -22,6 +22,12 @@ expect('file.php')->toReturnUnique();
 Make sure a file or directory files returns an array with single words.
 ```php
 expect('file.php')->toReturnSingleWords();
+```
+
+### toBeOrdered
+Make sure a file or directory files returns an array with words that are ordered.
+```php
+expect('file.php')->toBeOrdered();
 ```
 
 ----

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -6,7 +6,7 @@ use Faissaloux\PestInside\Expectation;
 use Pest\Expectation as PestExpectation;
 
 $expectations = get_class_methods(Expectation::class);
-$expectations = array_filter($expectations, fn ($function): bool => str_starts_with($function, 'toReturn'));
+$expectations = array_filter($expectations, fn ($function): bool => str_starts_with($function, 'toReturn') || str_starts_with($function, 'toBe'));
 
 foreach ($expectations as $expectation) {
     expect()->extend(

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -34,4 +34,13 @@ final class Expectation extends Inside
             'Not single words detected'
         );
     }
+
+    public function toBeOrdered(int $depth = -1): void
+    {
+        $this->applyOnDirectory(
+            $depth,
+            fn (array $content): array => $this->dataNotOrderedIn($content),
+            'Your data is not ordered'
+        );
+    }
 }

--- a/src/Investigator.php
+++ b/src/Investigator.php
@@ -89,14 +89,35 @@ trait Investigator
      */
     private function dataNotOrderedIn(array $array): array
     {
-        $unwanted = [];
-        $word = $array[0];
+        if (count($array) < 2) {
+            return [];
+        }
 
-        for ($index = 1; $index < count($array); $index++) {
-            if ($word > $array[$index]) {
-                $unwanted[] = "$word <=> $array[$index]";
+        $unwanted = [];
+        $lastWord = $array[0];
+
+        foreach ($array as $key => $value) {
+            if ($key === 0) {
+                continue;
             }
-            $word = $array[$index];
+
+            $currentWord = $value;
+            if (is_array($currentWord) && is_string($lastWord)) {
+                if ($lastWord > $key) {
+                    $unwanted[] = "$lastWord <=> $key";
+                }
+                $lastWord = $key;
+
+                array_push($unwanted, ...$this->dataNotOrderedIn($currentWord));
+
+                continue;
+            }
+
+            if (is_string($currentWord) && is_string($lastWord) && $lastWord > $currentWord) {
+                $unwanted[] = "$lastWord <=> $currentWord";
+            }
+
+            $lastWord = $currentWord;
         }
 
         return $unwanted;

--- a/src/Investigator.php
+++ b/src/Investigator.php
@@ -82,4 +82,23 @@ trait Investigator
 
         return $unwanted;
     }
+
+    /**
+     * @param  array<string|array<string>>  $array
+     * @return array<string>
+     */
+    private function dataNotOrderedIn(array $array): array
+    {
+        $unwanted = [];
+        $word = $array[0];
+
+        for ($index = 1; $index < count($array); $index++) {
+            if ($word > $array[$index]) {
+                $unwanted[] = "$word <=> $array[$index]";
+            }
+            $word = $array[$index];
+        }
+
+        return $unwanted;
+    }
 }

--- a/test.php
+++ b/test.php
@@ -1,0 +1,34 @@
+<?php
+
+$array = [
+    '',
+    'f@issA!oux',
+    'pest',
+    'plugin',
+    'inside',
+    'lowercase',
+    'lower',
+    'case',
+];
+
+sort($array);
+
+// array(8) {
+//     [0]=>
+//     string(0) ""
+//     [1]=>
+//     string(4) "case"
+//     [2]=>
+//     string(10) "f@issA!oux"
+//     [3]=>
+//     string(6) "inside"
+//     [4]=>
+//     string(5) "lower"
+//     [5]=>
+//     string(9) "lowercase"
+//     [6]=>
+//     string(4) "pest"
+//     [7]=>
+//     string(6) "plugin"
+//   }
+var_dump($array);

--- a/tests/Fixtures/alphaOrder/arrayNotOrdered.php
+++ b/tests/Fixtures/alphaOrder/arrayNotOrdered.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    '',
+    'f@issA!oux',
+    'pest',
+    'plugin',
+    'inside',
+    'lowercase',
+    'lower',
+    'case',
+];

--- a/tests/Fixtures/alphaOrder/arrayOrdered.php
+++ b/tests/Fixtures/alphaOrder/arrayOrdered.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    '',
+    'case',
+    'f@issA!oux',
+    'inside',
+    'lower',
+    'lowercase',
+    'pest',
+    'plugin',
+];

--- a/tests/Fixtures/alphaOrder/nestedArrayNotOrdered.php
+++ b/tests/Fixtures/alphaOrder/nestedArrayNotOrdered.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    '',
+    'case',
+    'f@issA!oux',
+    'inside',
+    'lower',
+    'lowercase',
+    'pest',
+    'plugin' => [
+        'pest',
+        'inSide',
+    ],
+];

--- a/tests/Fixtures/alphaOrder/nestedArrayOrdered.php
+++ b/tests/Fixtures/alphaOrder/nestedArrayOrdered.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    '',
+    'case',
+    'f@issA!oux',
+    'inside',
+    'lower',
+    'lowercase',
+    'pest',
+    'plugin' => [
+        'inSide',
+        'pest',
+    ],
+];

--- a/tests/Unit/helpers/getFilesIn.php
+++ b/tests/Unit/helpers/getFilesIn.php
@@ -5,7 +5,7 @@ uses()->group('helpers');
 it('gets all php files in directory and subdirectories', function (): void {
     $files = getFilesIn('tests/Fixtures');
 
-    expect($files)->toBeArray()->toHaveCount(18);
+    expect($files)->toBeArray()->toHaveCount(20);
 });
 
 it('gets all direct php files in directory', function (): void {
@@ -17,11 +17,11 @@ it('gets all direct php files in directory', function (): void {
 it('gets all php files in directory depth 1', function (): void {
     $files = getFilesIn('tests/Fixtures', depth: 1);
 
-    expect($files)->toBeArray()->toHaveCount(16);
+    expect($files)->toBeArray()->toHaveCount(18);
 });
 
 it('gets all php files in directory and subdirectories on negative depth', function (): void {
     $files = getFilesIn('tests/Fixtures', depth: -4);
 
-    expect($files)->toBeArray()->toHaveCount(18);
+    expect($files)->toBeArray()->toHaveCount(20);
 });

--- a/tests/Unit/helpers/getFilesIn.php
+++ b/tests/Unit/helpers/getFilesIn.php
@@ -5,7 +5,7 @@ uses()->group('helpers');
 it('gets all php files in directory and subdirectories', function (): void {
     $files = getFilesIn('tests/Fixtures');
 
-    expect($files)->toBeArray()->toHaveCount(20);
+    expect($files)->toBeArray()->toHaveCount(22);
 });
 
 it('gets all direct php files in directory', function (): void {
@@ -17,11 +17,11 @@ it('gets all direct php files in directory', function (): void {
 it('gets all php files in directory depth 1', function (): void {
     $files = getFilesIn('tests/Fixtures', depth: 1);
 
-    expect($files)->toBeArray()->toHaveCount(18);
+    expect($files)->toBeArray()->toHaveCount(20);
 });
 
 it('gets all php files in directory and subdirectories on negative depth', function (): void {
     $files = getFilesIn('tests/Fixtures', depth: -4);
 
-    expect($files)->toBeArray()->toHaveCount(20);
+    expect($files)->toBeArray()->toHaveCount(22);
 });

--- a/tests/toReturnAlphaOrdered.php
+++ b/tests/toReturnAlphaOrdered.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('passes', function (): void {
+    expect('tests/Fixtures/alphaOrder/arrayOrdered.php')
+        ->toBeOrdered();
+});
+
+it('passes with not', function (): void {
+    expect('tests/Fixtures/alphaOrder/arrayNotOrdered.php')
+        ->not->toBeOrdered();
+});
+
+it('passes when all nested arrays content is ordered', function (): void {
+    expect('tests/Fixtures/alphaOrder/nestedArrayOrdered.php')
+        ->toBeOrdered();
+})->only();
+
+it('fails', function (): void {
+    expect('tests/Fixtures/alphaOrder/arrayNotOrdered.php')
+        ->toBeOrdered();
+})->throws(ExpectationFailedException::class);
+
+it('fails with not', function (): void {
+    expect('tests/Fixtures/alphaOrder/arrayOrdered.php')
+        ->not->toBeOrdered();
+})->throws(ExpectationFailedException::class);
+
+it('fails when not all nested arrays content is ordered', function (): void {
+    expect('tests/Fixtures/alphaOrder/nestedArrayNotOrdered.php')
+        ->toBeOrdered();
+})->throws(ExpectationFailedException::class, 'Your data is not ordered: pest <=> inSide');

--- a/tests/toReturnAlphaOrdered.php
+++ b/tests/toReturnAlphaOrdered.php
@@ -15,7 +15,7 @@ it('passes with not', function (): void {
 it('passes when all nested arrays content is ordered', function (): void {
     expect('tests/Fixtures/alphaOrder/nestedArrayOrdered.php')
         ->toBeOrdered();
-})->only();
+});
 
 it('fails', function (): void {
     expect('tests/Fixtures/alphaOrder/arrayNotOrdered.php')


### PR DESCRIPTION
This PR introduces a new expectation `toBeOrdered()`, which makes sure your php file returns an ordered array.

#### Success
`file.php` returns ordered values.
```php
// file.php

return [
    'inside',
    'lower',
    'lowercase',
    'pest',
    'plugin',
];
```

#### Fails
`file.php` returns unordered values.
```php
// file.php

return [
    'pest',
    'plugin',
    'inside',
    'lowercase',
    'lower',
];
```