### PR TITLE
`toReturnStrings()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Make sure a file or directory files returns an array with words that are ordered
 expect('file.php')->toBeOrdered();
 ```
 
+### toReturnStrings
+Make sure a file or directory files returns only string values.
+```php
+expect('file.php')->toReturnStrings();
+```
+
 ----
 
 ### Success

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -43,4 +43,13 @@ final class Expectation extends Inside
             'Your data is not ordered'
         );
     }
+
+    public function toReturnStrings(int $depth = -1): void
+    {
+        $this->applyOnDirectory(
+            $depth,
+            fn (array $content): array => $this->notStringsIn($content),
+            'Not string detected'
+        );
+    }
 }

--- a/src/Investigator.php
+++ b/src/Investigator.php
@@ -122,4 +122,27 @@ trait Investigator
 
         return $unwanted;
     }
+
+    /**
+     * @param  array<string|array<string>>  $array
+     * @return array<string>
+     */
+    private function notStringsIn(array $array): array
+    {
+        $unwanted = [];
+
+        foreach ($array as $word) {
+            if (is_array($word)) {
+                array_push($unwanted, ...$this->notStringsIn($word));
+
+                continue;
+            }
+
+            if (! is_string($word)) {
+                $unwanted[] = $word;
+            }
+        }
+
+        return $unwanted;
+    }
 }

--- a/tests/Fixtures/returnsNestedNotUnique.php
+++ b/tests/Fixtures/returnsNestedNotUnique.php
@@ -12,6 +12,7 @@ return [
         'pest',
         'inSide',
         'pest',
+        1,
     ],
     'plugin',
     'inside',

--- a/tests/toReturnStrings.php
+++ b/tests/toReturnStrings.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('passes', function (): void {
+    expect('tests/Fixtures/returnsDuplicates.php')
+        ->toReturnStrings();
+});
+
+it('passes with not', function (): void {
+    expect('tests/Fixtures/returnsMultipleDuplicates.php')
+        ->not->toReturnStrings();
+});
+
+it('passes when all nested arrays content is string', function (): void {
+    expect('tests/Fixtures/returnsNestedLowercase.php')
+        ->toReturnStrings();
+});
+
+it('fails', function (): void {
+    expect('tests/Fixtures/returnsMultipleDuplicates.php')
+        ->toReturnStrings();
+})->throws(ExpectationFailedException::class);
+
+it('fails with not', function (): void {
+    expect('tests/Fixtures/returnsDuplicates.php')
+        ->not->toReturnStrings();
+})->throws(ExpectationFailedException::class);
+
+it('fails when not all nested arrays content is string', function (): void {
+    expect('tests/Fixtures/returnsNestedNotUnique.php')
+        ->toReturnStrings();
+})->throws(ExpectationFailedException::class, 'Not string detected: 1');


### PR DESCRIPTION
This PR introduces a new expectation `toReturnStrings()`, which makes sure your php file returns only strings.

#### Success
`file.php` returns only strings.
```php
// file.php

return [
    'inside',
    'pest',
    'plugin',
];
```

#### Fails
`file.php` returns a number with strings.
```php
// file.php

return [
    'pest',
    'plugin',
    1,
    'inside',
];
```