### PR TITLE
`forbidEmpty()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Make sure a file or directory files returns only string values.
 expect('file.php')->toReturnStrings();
 ```
 
+### forbidEmpty
+Make sure a file or directory files does not return any empty value.
+```php
+expect('file.php')->forbidEmpty();
+```
+
 ----
 
 ### Success

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -6,8 +6,7 @@ use Faissaloux\PestInside\Expectation;
 use Pest\Expectation as PestExpectation;
 
 $expectations = get_class_methods(Expectation::class);
-$expectations = array_filter($expectations, fn ($function): bool =>
-    str_starts_with($function, 'toReturn')
+$expectations = array_filter($expectations, fn ($function): bool => str_starts_with($function, 'toReturn')
     || str_starts_with($function, 'toBe')
     || str_starts_with($function, 'forbid')
 );

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -6,7 +6,11 @@ use Faissaloux\PestInside\Expectation;
 use Pest\Expectation as PestExpectation;
 
 $expectations = get_class_methods(Expectation::class);
-$expectations = array_filter($expectations, fn ($function): bool => str_starts_with($function, 'toReturn') || str_starts_with($function, 'toBe'));
+$expectations = array_filter($expectations, fn ($function): bool =>
+    str_starts_with($function, 'toReturn')
+    || str_starts_with($function, 'toBe')
+    || str_starts_with($function, 'forbid')
+);
 
 foreach ($expectations as $expectation) {
     expect()->extend(

--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -63,4 +63,13 @@ final class Expectation extends Inside
             'Not string detected'
         );
     }
+
+    public function forbidEmpty(int $depth = -1): void
+    {
+        $this->applyOnDirectory(
+            $depth,
+            fn (Content $content): bool => $this->emptyIn($content),
+            'Empty value detected'
+        );
+    }
 }

--- a/src/Inside.php
+++ b/src/Inside.php
@@ -52,7 +52,11 @@ class Inside
 
             $unwanted = $callback($content);
 
-            expect($unwanted)->toBeEmpty("$message: ".implode(', ', $unwanted)." in $file");
+            if (is_array($unwanted)) {
+                expect($unwanted)->toBeEmpty("$message: ".implode(', ', $unwanted)." in $file");
+            } else {
+                expect($unwanted)->toBeTrue($message);
+            }
         }
 
         return new PestExpectation($this->value);

--- a/src/Investigator.php
+++ b/src/Investigator.php
@@ -176,4 +176,24 @@ trait Investigator
 
         return $unwanted;
     }
+
+    /**
+     * @param  Content|array<int|string, string|array<string, string>>  $content
+     */
+    private function emptyIn(Content|array $content): bool
+    {
+        foreach ($content as $word) {
+            if (is_array($word)) {
+                $this->emptyIn($word);
+
+                continue;
+            }
+
+            if ($word == '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/tests/Fixtures/returnsMultipleDuplicates.php
+++ b/tests/Fixtures/returnsMultipleDuplicates.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 return [
-    '',
     'f@issa!oux',
     1,
     'pest',

--- a/tests/Fixtures/text/returnsMultipleDuplicates.stub
+++ b/tests/Fixtures/text/returnsMultipleDuplicates.stub
@@ -1,4 +1,3 @@
-
 f@issa!oux
 1
 pest

--- a/tests/forbidEmpty.php
+++ b/tests/forbidEmpty.php
@@ -1,0 +1,25 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('passes', function (string $file): void {
+    expect($file)->forbidEmpty();
+})->with([
+    'tests/Fixtures/returnsMultipleDuplicates.php',
+    'tests/Fixtures/text/returnsMultipleDuplicates.stub',
+]);
+
+it('fails', function (string $file): void {
+    expect($file)->forbidEmpty();
+})->with([
+    'tests/Fixtures/returnsDuplicates.php',
+    'tests/Fixtures/text/returnsDuplicates.stub',
+])->throws(ExpectationFailedException::class, 'Empty value detected');
+
+it('passes when directory is empty', function (): void {
+    expect('tests/Fixtures/empty')->forbidEmpty();
+});
+
+it('fails when directory does not exist', function (): void {
+    expect('tests/Fixtures/notExist')->forbidEmpty();
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
This PR introduces a new expectation `forbidEmpty()`, which makes sure your files does not return any empty value.

#### Success
```php
// file1.php

return [
    'pest',
    'plugin inside',
];
```

#### Fails
```php
// file2.php

return [
    'pest',
    'plugin inside',
    '',
];
```

#### Tests
```php
expect('file1.php')->forbidEmpty();    // PASS
expect('file2.php')->forbidEmpty();    // FAILS
```